### PR TITLE
Increase marker size in graph

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -121,7 +121,7 @@ function App() {
           color: colors[index % colors.length]
         },
         marker: {
-          size: 6,
+          size: 10,
           symbol: 'circle',
           color: colors[index % colors.length],
           line: {


### PR DESCRIPTION
## Summary
- enlarge scatter plot markers for better visibility

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684eba86459c8328884dcf6f2ec75eb1